### PR TITLE
added zuggs proposed spells

### DIFF
--- a/antillurgy.json
+++ b/antillurgy.json
@@ -1325,6 +1325,68 @@
       "miscTags": [
         "SGT"
       ]
+    },
+    {
+      "name": "Shield of Cunning",
+      "level": 2,
+      "school": "antillurgy",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "s": true,
+        "v": true,
+        "m": "Polished Mithril"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 8
+          },
+          "concentration": false
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Bard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "source": "nario",
+      "entries": [
+        "You touch a willing creature who isn't wearing armor, and a protective magical force surrounds it until the spell ends. The target's base AC becomes 13 + its Intelligence modifier. The spell ends if the target dons armor or if you dismiss the spell as an action.",
+        "Overload: The creature may choose to overload the shield as a reaction, causing a psychic shockwave to emit 5 ft from the creature. All creatures in range must make an Intelligence saving throw against the spell caster’s DC, or be stunned until the end of their next turn. This will expend the shield."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "The radius of the shell increases by 100ft for every spell slot used above 3rd."
+          ]
+        }
+      ]
     }
   ]
 }

--- a/chronomancy.json
+++ b/chronomancy.json
@@ -550,6 +550,9 @@
           "concentration": true
         }
       ],
+      "meta": {
+        "ritual": true
+      },
       "classes": {
         "fromClassList": [
           {
@@ -1558,6 +1561,69 @@
       },
       "entries": [
         "You form a rip in time into the shape of a wall within range. You can make a straight wall up to 60 feet long, 20 feet high, and 1 foot thick, or a circular wall up to 20 feet high, 1 foot thick, and forming a closed circle 20 feet in diameter.  Nonmagical ranged attacks that cross the wall vanish into time with no other effect. Ranged spell attacks and ranged weapon attacks made with magical weapons that pass through the wall are made with disadvantage. A creature that intentionally enters or passes through the wall is affected as if they had just failed their initial saving throw against the {@spell slow|phb} spell."
+      ]
+    },
+    {
+      "name": "Lyrr’s Chronomantic Shell",
+      "level": 3,
+      "school": "chronomancy",
+      "time": [
+        {
+          "number": 1,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "s": true,
+        "v": true,
+        "m": "A pocket watch set to a certain time"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 8
+          },
+          "concentration": false
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Bard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "source": "nario",
+      "entries": [
+        "Create a shell centered to a relative point (like a ship’s mask). From this point, there is a sphere with a radius of 100 ft. Within this sphere, the climate is sent back in time to a climate of the caster’s choice.",
+        "For example, a caster can place this shell around a ship to give it calm waters for 8 hours, no matter the surrounding."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "The radius of the shell increases by 100ft for every spell slot used above 3rd."
+          ]
+        }
       ]
     }
   ]

--- a/mercuromancy.json
+++ b/mercuromancy.json
@@ -1227,6 +1227,77 @@
       "miscTags": [
         "HL"
       ]
+    },
+    {
+      "name": "Gift of the Archmage",
+      "source": "nario",
+      "level": 5,
+      "school": "mercuromancy",
+      "time": [
+        {
+          "number": 1,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 5
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a palm sized stone of unrefined |SPECIAL MAGIC METAL THAT IS GREEN| ore that costs 1000 gp OR MARKET PRICE FOR THAT SIZE "
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "entries": [
+        "You use the stone in your hand as a conduit for fate, causing it to emit a blue glow. Using the stone, you sketch out complicated arcane sigil in the air. Once fully drawn, the sigil will shrink into a tiny sphere, changing in color to pure white. This singularity will go into a willing creature, imbuing the creature with distilled energy from weave.",
+        "This creature will gain the ability to cast a 4th level spell or lower that is known to you, and in the wizard spell book. This spell will use the creature’s intelligence modifier, and can only be cast once.",
+        "The strain of distilling a spell into a gift, will cause great fatigue to the original spell caster. The spell caster suffers one point of exhaustion, and cannot cast this spell again for 24 hours."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell using a spell slot of 6th level or higher, the distilled spell singularity can hold a greater spell level for each slot level above 5th. However, the strain increases, and the caster suffers an additional level of exhaustion for every spell slot above 5th."
+          ]
+        }
+      ]
     }
   ]
 }

--- a/planara.json
+++ b/planara.json
@@ -1704,6 +1704,76 @@
       "miscTags": [
         "SGT"
       ]
+    },
+    {
+      "name": "Bending Bolt",
+      "source": "nario",
+      "level": 4,
+      "school": "planara",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "line",
+        "distance": {
+          "type": "feet",
+          "amount": 120
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "meta": {
+        "ritual": false
+      },
+      "entries": [
+        "A stroke of lightning forming a line 120 feet long and 5 feet wide blasts out from you in a direction you choose. Each creature in the line must make a Dexterity saving throw. A creature takes {@damage 8d6} lightning damage on a failed save, or half as much damage on a successful one.",
+        "The spell caster can force the bolt to bend to its will, causing the lightning to bend at a point where the angle does not exceed more than 90˚."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell using a spell slot of 5th level or higher, the caster can add an inflection point for every spell slot above 4th. Every inflection point must be at least 5 ft apart."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "lightning"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          },
+          {
+            "name": "Seeker",
+            "source": "SW"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Spell Name: Lyrr’s Chronomantic Shell

Balance Justification: Is it much like a hut with the climate, but does not offer magical protection. It also cannot make a warm climate in a place that is permanently cold. Or for example, bring air to the water plane. Its smaller than a mansion and does not feed.

=========================================================================================
Spell Name: Bending Bolt

Balance Justification: It’s a lightning bolt that has actual utility, and the damage does not scale, only the points. You also cannot make a 180˚ angle. 

=========================================================================================
Spell Name: Shield of Cunning

Balance Justification: It is similar to mage armor. The overload feature is very situational, and risky. If it does not stun, the mage is left without the ac advantage. It also only stuns for 1 round.

=========================================================================================
Spell Name: Gift of the Archmage

Balance Justification: It cannot be used in combat due to the casting time, and has heavier penalties than lesser wish. It also uses the receivers spell casting modifier. 